### PR TITLE
Fix Formatting for spec.registry example

### DIFF
--- a/calico_versioned_docs/version-3.26/operations/image-options/alternate-registry.mdx
+++ b/calico_versioned_docs/version-3.26/operations/image-options/alternate-registry.mdx
@@ -81,6 +81,6 @@ spec:
   variant: Calico
   imagePullSecrets:
     - name: tigera-pull-secret
-    // highlight-next-line
-      registry: myregistry.com
+  // highlight-next-line
+  registry: myregistry.com
 ```


### PR DESCRIPTION
@tigera/docs,
Quick fix to indentation/formatting for the spec.registry example.

Product Version(s):
N/A - Just documentation fix.

DOCS review:
- [ ] A member of the docs team has approved this change.

Merge checklist:
N/A doco change.
